### PR TITLE
Update terraform version transfer and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Perform `terraform login` to ensure that your local Terraform can interact with 
 
 ### Export the resource definitions and Terraform state
 
-- Choose the transformer and locate the example of `terraform.tfvars.example` and rename it to `terraform.tfvars`.
+- Choose the transformer and copy `terraform.tfvars.example` to `terraform.tfvars`.
 - Edit terraform.tfvars with appropriate variables.
 - Run the following commands:
 
@@ -37,11 +37,11 @@ terraform apply -auto-approve -var-file=terraform.tfvars
 
 A new `export` folder should have been created. The `sg-payload.json` file contains the definition for each workflow that will be created for each Terraform Workspace, and the `states` folder contains the files for the Terraform state for each of your workspaces, if the state export was enabled.
 
-After completing the export , edit the `sg-payload.json` file to provide tune each workflow configuration with the following:
+After completing the export, edit the `sg-payload.json` file to tune each workflow configuration with the following:
 
 ### Use the example_payload.jsonc file as a reference and edit the schema of the `sg-payload.json`
 
-- `DeploymentPlatformConfig` - This is used to authenticate against a cloud provider using a StackGuardian Integration. Create the relevant integration in StackGuardian platform and update `DeploymentPlatformConfig.kind` from the following "AZURE_STATIC", "AWS_STATIC","GCP_STATIC", "AWS_RBAC". Update `DeploymentPlatformConfig.config.integrationId` with "/integrations/INTEGRATION_NAME" and `DeploymentPlatformConfig.config.profileName` with the name of the integration used upon creation.
+- `DeploymentPlatformConfig` - This is used to authenticate against a cloud provider using a StackGuardian Integration. Create the relevant integration in StackGuardian platform and update `DeploymentPlatformConfig.kind` to one of the following "AZURE_STATIC", "AWS_STATIC","GCP_STATIC", "AWS_RBAC". Update `DeploymentPlatformConfig.config.integrationId` with "/integrations/INTEGRATION_NAME" and `DeploymentPlatformConfig.config.profileName` with the name of the integration used upon creation.
 
 ```
   DeploymentPlatformConfig: [
@@ -55,7 +55,7 @@ After completing the export , edit the `sg-payload.json` file to provide tune ea
   ]
 ```
 
-- `VCSConfig` - Provide full path to the `repo` like as well the relevant `sourceConfigDestKind` from the following "GITHUB_COM", "BITBUCKET_ORG", "GITLAB_COM", "AZURE_DEVOPS"
+- `VCSConfig` - Provide the full path to the `repo`, as well as the relevant `sourceConfigDestKind` from the following "GITHUB_COM", "BITBUCKET_ORG", "GITLAB_COM", "AZURE_DEVOPS"
   - `config.auth`
   - `config.isPrivate`
 - `ResourceName` - name of your StackGuardian Workflow
@@ -80,13 +80,24 @@ After completing the export , edit the `sg-payload.json` file to provide tune ea
 - `UserSchedules` - Scheduled workflow run configuration for the workflow in the StackGuardian platform
 - `MiniSteps` - Ministeps for the workflow to direct the process if the workflow returns an error/success/approval required and workflow chaining
 
+### Convert HCL variables to JSON
+
+HCL variables from Terraform Cloud appear as strings in `sg-payload.json` and need to be converted to JSON before importing.
+
+Run the script from the repo root, passing the exported payload. It rewrites the file in place — converting the HCL-string variable values under `VCSConfig.iacInputData.data` into JSON — so none of the following steps need any change. The script downloads `jq` and `hcl2json` at runtime.
+
+```shell
+./convert_hcl_to_json.sh export/sg-payload.json
+```
+
 ### Bulk import workflows to StackGuardian Platform
 
 - Fetch [sg-cli](https://github.com/StackGuardian/sg-cli.git) and set it up locally (documentation present in repo)
 - Run the following commands and pass the `sg-payload.json` as payload (represented below)
+- `--workflow-group` is required even though `wfgrpName` is set in the payload. Pass the workflow group ID (e.g. `prj-ThpsFFz59kqFaVr4`).
 - Get your SG API Key here:
   - Login to Stackguardian.
-  - Go to profile at the bottom left. Click on the eamil or the username.
+  - Go to profile at the bottom left. Click on the email or the username.
   - Click API key and click on view.
 
 ```shell
@@ -95,20 +106,11 @@ cd ../../export
 export SG_API_TOKEN=<YOUR_SG_API_TOKEN>
 wget -q "$(wget -qO- "https://api.github.com/repos/stackguardian/sg-cli/releases/latest" | jq -r '.tarball_url')" -O sg-cli.tar.gz && tar -xf sg-cli.tar.gz && rm -f sg-cli.tar.gz && /bin/cp -rf StackGuardian-sg-cli*/shell/sg-cli . && rm -rfd StackGuardian-sg-cli*
 
-./sg-cli workflow create --bulk --org "<ORG NAME>" -- sg-payload.json
+./sg-cli workflow create --bulk --workflow-group "<WORKFLOW GROUP ID>" --org "<ORG NAME>" -- sg-payload.json
 ```
 
 if you want to update a workflow with different details, please re-run the sg-cli command with the modified sg-payload.json and your workflow will be updated with the new details, as long as the ResourceName (Workflow name) remains the same.
 
 ```shell
-./sg-cli workflow create --bulk --org "<ORG NAME>" -- sg-payload.json
-```
-
-## Convert hcl variables to json
-
-HCL variables in terraform cloud appear as strings in sg-payload.json, which needs to be converted to json.</br >
-It will change the file input file in place so that none of the other steps need any change.
-
-```shell
-./convert_hcl_to_json.sh <intput_file>
+./sg-cli workflow create --bulk --workflow-group "<WORKFLOW GROUP ID>" --org "<ORG NAME>" -- sg-payload.json
 ```

--- a/transformer/terraform-cloud/example_payload.jsonc
+++ b/transformer/terraform-cloud/example_payload.jsonc
@@ -33,7 +33,7 @@
   "Tags": [], // workflow tags
   "TerraformConfig": {
     "managedTerraformState": true, // managed state from StackGuardian
-    "terraformVersion": "1.1.6" // version of terraform
+    "terraformVersion": "TERRAFORM-1.1.6" // version of terraform
   },
   "UserSchedules": [],
   "VCSConfig": {

--- a/transformer/terraform-cloud/locals.tf
+++ b/transformer/terraform-cloud/locals.tf
@@ -60,7 +60,7 @@ locals {
 
     TerraformConfig = {
       "managedTerraformState" : true,
-      "terraformVersion" : data.tfe_workspace.data[i].terraform_version,
+      "terraformVersion" : "TERRAFORM-${data.tfe_workspace.data[i].terraform_version}",
       "approvalPreApply" : !data.tfe_workspace.data[i].auto_apply
     }
 


### PR DESCRIPTION
## Summary:
This PR updates the Terraform version transfer flow to preserve the Terraform Cloud version in the StackGuardian payload using the expected `TERRAFORM-` prefix. It also tightens the documentation for exporting, converting, and bulk importing workflows.

## Motivation & Context:
The migration logic needed to align with StackGuardian’s Terraform version format so imported workflows carry the correct version metadata. This change improves the reliability of Terraform version transfers during bulk workflow migration.

## Changes Made:
- Updated the payload schema example to set `TerraformConfig.terraformVersion` to `TERRAFORM-1.1.6`
- Changed the Terraform Cloud conversion logic to prefix exported workspace versions with `TERRAFORM-`
- Refined README migration steps for exporting Terraform definitions and state
- Clarified how to copy `terraform.tfvars.example` to `terraform.tfvars`
- Added guidance for converting HCL string variables to JSON with `convert_hcl_to_json.sh`
- Simplified and corrected bulk import instructions for `sg-cli`
- Fixed wording and formatting issues throughout the migration documentation

## Risks & Edge Cases:
- Existing payloads without the `TERRAFORM-` prefix may need regeneration before import
- The conversion script downloads `jq` and `hcl2json` at runtime, so network access is required

## Deployment Notes:
- No code deployment or database migration is required
- Regenerate `sg-payload.json` using the updated conversion flow before importing workflows